### PR TITLE
Feat/get datasets query parameters

### DIFF
--- a/examples/fishnet_api/main.py
+++ b/examples/fishnet_api/main.py
@@ -128,9 +128,6 @@ async def datasets(view_as: Optional[str], by: Optional[str], page: Optional[int
     #     - fetch all timeseries for each dataset,
     ts_ids_lst = list(ts_ids_unique)
 
-
-
-
     # This whole block should be executed for each fetched Dataset.Also, return the Dataset with it, not only the PermissionStatus.
     dataset_by_requestor = await Dataset.where_eq(timeseriesIDs=ts_ids_lst)
     #   - get all permissions for each timeseries & given requestor

--- a/examples/fishnet_api/main.py
+++ b/examples/fishnet_api/main.py
@@ -36,7 +36,7 @@ http_app.add_middleware(
     allow_headers=["*"],
 )
 
-if getenv("TEST_CACHE").lower() == "true":
+if getenv("TEST_CACHE") is not None and getenv("TEST_CACHE").lower() == "true":
     cache = TestVmCache()
 else:
     cache = VmCache()

--- a/examples/fishnet_api/main.py
+++ b/examples/fishnet_api/main.py
@@ -97,13 +97,28 @@ async def index():
 
 
 @app.get("/datasets")
-async def datasets() -> List[Dataset]:
+async def datasets(view_as: Optional[str], by: Optional[str]) -> List[Tuple[Dataset, Optional[PermissionStatus]]]:
+    """
+    Get all datasets.
+
+    :param view_as: address of the user to view the datasets as and give additional permission information
+    :param by: address of the dataset owner to filter by
+    """
+    # TODO:
+    # - for the Owner (by) parameter:
+    #     - fetch all datasets for the owner
+    # - for the Requestor (view_as) parameter:
+    #     - fetch all timeseries for each dataset,
+    #     - get all permissions for each timeseries & given requestor
+    #     - respond with permission for dataset as approved, if all permissions are approved
+    #     - respond with pending if at least one is still pending
+    #     - respond with denied if at lest one is denied
     return await Dataset.fetch_all()
 
-
-@app.get("/user/{address}/datasets")
-async def get_user_datasets(address: str) -> List[Dataset]:
-    return await Dataset.query(owner=address)
+# This is not necessary, as it will be replaced by GET /datasets?by={address}
+#@app.get("/user/{address}/datasets")
+#async def get_user_datasets(address: str) -> List[Dataset]:
+#    return await Dataset.query(owner=address)
 
 
 @app.get("/algorithms")

--- a/examples/fishnet_api/main.py
+++ b/examples/fishnet_api/main.py
@@ -127,7 +127,8 @@ async def datasets(view_as: Optional[str], by: Optional[str], page: Optional[int
     #     - fetch all timeseries for each dataset,
     ts_ids_lst = list(ts_ids_unique)
 
-    # This whole block should be executed for each fetched Dataset.Also, return the Dataset with it, not only the PermissionStatus.
+    # This whole block should be executed for each fetched Dataset.
+    # Also, return the Dataset with it, not only the PermissionStatus.
 
     dataset_by_requestor = await Dataset.where_eq(timeseriesIDs=ts_ids_lst)
     #   - get all permissions for each timeseries & given requestor
@@ -137,23 +138,21 @@ async def datasets(view_as: Optional[str], by: Optional[str], page: Optional[int
         #   - get all permissions for each timeseries & given requestor
         permission_records = await Permission.where_eq(timeseriesID=rec.timeseriesIDs, requestor=view_as)
         permission_status = []
+        # if there is no permission records its mean  dataset are not requested
         if not permission_records:
             returned_datasets.append((rec, DatasetPermissionStatus.NOT_REQUESTED))
-            return returned_datasets
         for perm_rec in permission_records:
             permission_status.append(perm_rec.status)
         #   - respond with permission for dataset as approved, if all permissions are approved
         if all(status == PermissionStatus.GRANTED for status in permission_status):
             returned_datasets.append((rec, DatasetPermissionStatus.GRANTED))
-            return returned_datasets
-            #     - respond with denied if at lest one is denied
+        #     - respond with denied if at least one is denied
         elif PermissionStatus.DENIED in permission_status:
             returned_datasets.append((rec, DatasetPermissionStatus.DENIED))
-            return returned_datasets
-            #     - respond with pending if at least one is still pending
+        #     - respond with pending if at least one is still pending
         elif PermissionStatus.REQUESTED in permission_status:
             returned_datasets.append((rec, DatasetPermissionStatus.REQUESTED))
-            return returned_datasets
+    return returned_datasets
 
 
 # This is not necessary, as it will be replaced by GET /datasets?by={address}

--- a/examples/fishnet_api/main.py
+++ b/examples/fishnet_api/main.py
@@ -97,7 +97,7 @@ async def index():
 
 
 @app.get("/datasets")
-async def datasets(view_as: Optional[str], by: Optional[str]) -> str:
+async def datasets(view_as: Optional[str], by: Optional[str], page: Optional[int], page_size: Optional[int]) :
     """
     Get all datasets.
 
@@ -121,7 +121,7 @@ async def datasets(view_as: Optional[str], by: Optional[str]) -> str:
         permission_status.append(rec.status)
     #   - respond with permission for dataset as approved, if all permissions are approved
     if all(rec == PermissionStatus.GRANTED for rec in permission_status):
-        return "Dataset Available"
+        return "granted"
     #     - respond with pending if at least one is still pending
     elif PermissionStatus.REQUESTED in permission_status:
         return "Dataset Requested"
@@ -131,14 +131,14 @@ async def datasets(view_as: Optional[str], by: Optional[str]) -> str:
 
 
 # This is not necessary, as it will be replaced by GET /datasets?by={address}
-#@app.get("/user/{address}/datasets")
-#async def get_user_datasets(address: str) -> List[Dataset]:
+# @app.get("/user/{address}/datasets")
+# async def get_user_datasets(address: str) -> List[Dataset]:
 #    return await Dataset.save(owner=address)
 
 
 @app.get("/algorithms")
-async def get_algorithms() -> List[Algorithm]:
-    return await Algorithm.fetch_all()
+async def get_algorithms(page: Optional[int], page_size: Optional[int]) -> List[Algorithm]:
+    return await Algorithm.fetch_all(page=page, page_size=page_size)
 
 
 @app.get("/user/{address}/algorithms")
@@ -147,8 +147,8 @@ async def get_user_algorithms(address: str) -> List[Algorithm]:
 
 
 @app.get("/executions")
-async def get_executions() -> List[Execution]:
-    return await Execution.fetch_all()
+async def get_executions(page: Optional[int], page_size: Optional[int]) -> List[Execution]:
+    return await Execution.fetch_all(page=page, page_size=page_size)
 
 
 @app.get("/executions/{dataset_ID}")

--- a/examples/fishnet_api/main.py
+++ b/examples/fishnet_api/main.py
@@ -113,9 +113,6 @@ async def datasets(
     :param page_size: size of the pages to fetch
     :param page: page number to fetch
     """
-    # TODO:
-    # - for the Owner (by) parameter:
-    #     - fetch all datasets for the owner
 
     if by:
         datasets = await Dataset.where_eq(owner=by)
@@ -167,16 +164,19 @@ async def datasets(
     return returned_datasets
 
 
-# This is not necessary, as it will be replaced by GET /datasets?by={address}
-# @app.get("/user/{address}/datasets")
-# async def get_user_datasets(address: str) -> List[Dataset]:
-#    return await Dataset.save(owner=address)
-
-
 @app.get("/algorithms")
 async def get_algorithms(
-    page: Optional[int], page_size: Optional[int]
+    page: Optional[int], page_size: Optional[int], by: Optional[str]
 ) -> List[Algorithm]:
+    """
+    Get all algorithms.
+
+    :param page_size: size of the pages to fetch
+    :param page: page number to fetch
+    :param by: address of the algorithm owner to filter by
+    """
+    if by:
+        return await Algorithm.where_eq(owner=by)
     return await Algorithm.fetch_all(page=page, page_size=page_size)
 
 

--- a/examples/fishnet_api/main.py
+++ b/examples/fishnet_api/main.py
@@ -101,7 +101,8 @@ async def index():
 async def datasets(view_as: Optional[str], by: Optional[str], page: Optional[int], page_size: Optional[int]) -> List[
     Tuple[Dataset, Optional[DatasetPermissionStatus]]]:
     """
-    Get all datasets.
+    Get all datasets. Returns a list of tuples of datasets and their permission status for the given `view_as` user.
+    If `view_as` is not given, the permission status will be `none` for all datasets.
 
     :param view_as: address of the user to view the datasets as and give additional permission information
     :param by: address of the dataset owner to filter by
@@ -110,9 +111,12 @@ async def datasets(view_as: Optional[str], by: Optional[str], page: Optional[int
     # - for the Owner (by) parameter:
     #     - fetch all datasets for the owner
 
-    ds_by_owner = await Dataset.fetch_all(page=page, page_size=page_size)
+    if by:
+        datasets = await Dataset.where_eq(owner=by)
+    else:
+        datasets = await Dataset.fetch_all(page=page, page_size=page_size)
     ts_ids = []
-    for rec in ds_by_owner:
+    for rec in datasets:
         ts_ids.append(rec.timeseriesIDs)
 
     # convert into numpy array

--- a/examples/fishnet_api/requests.py
+++ b/examples/fishnet_api/requests.py
@@ -45,6 +45,3 @@ class RequestExecutionResponse(BaseModel):
     execution: Execution
     permissionRequests: Optional[List[Permission]]
     unavailableTimeseries: Optional[List[Timeseries]]
-
-
-

--- a/examples/fishnet_api/requirements.txt
+++ b/examples/fishnet_api/requirements.txt
@@ -1,4 +1,4 @@
-aleph-sdk-python~=0.6.0
+aleph-sdk-python
 aars~=0.3.3
 fishnet-cod~=0.1.0
 fastapi

--- a/examples/fishnet_api/requirements.txt
+++ b/examples/fishnet_api/requirements.txt
@@ -1,4 +1,4 @@
-aleph-client
-aars
-fishnet-cod
+aleph-sdk-python~=0.6.0
+aars~=0.3.3
+fishnet-cod~=0.1.0
 fastapi

--- a/examples/fishnet_api/requirements.txt
+++ b/examples/fishnet_api/requirements.txt
@@ -1,4 +1,4 @@
 aleph-sdk-python
-aars~=0.3.3
-fishnet-cod~=0.1.0
+aars
+fishnet-cod
 fastapi

--- a/examples/fishnet_api/test.py
+++ b/examples/fishnet_api/test.py
@@ -80,3 +80,9 @@ def test_execution_dataset():
     assert response.json()
     data = response.json()
     print("data", data)
+
+def test_dataset():
+    page = 1
+    page_size = 1
+    response = client.get('/datasets')
+

--- a/examples/fishnet_api/test.py
+++ b/examples/fishnet_api/test.py
@@ -81,8 +81,8 @@ def test_execution_dataset():
     data = response.json()
     print("data", data)
 
+
 def test_dataset():
     page = 1
     page_size = 1
-    response = client.get('/datasets')
-
+    response = client.get("/datasets")

--- a/examples/fishnet_cod/pyproject.toml
+++ b/examples/fishnet_cod/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fishnet-cod"
-version = "0.0.8"
+version = "0.1.0"
 authors = [
   { name="Mike Hukiewitz", email="mike.hukiewitz@robotter.ai" },
 ]

--- a/examples/fishnet_cod/pyproject.toml
+++ b/examples/fishnet_cod/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fishnet-cod"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Mike Hukiewitz", email="mike.hukiewitz@robotter.ai" },
 ]

--- a/examples/fishnet_cod/pyproject.toml
+++ b/examples/fishnet_cod/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fishnet-cod"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="Mike Hukiewitz", email="mike.hukiewitz@robotter.ai" },
 ]

--- a/examples/fishnet_cod/requirements.txt
+++ b/examples/fishnet_cod/requirements.txt
@@ -1,6 +1,6 @@
 pydantic
 aiohttp
-aleph_client
-aars
+aleph-sdk-python~=0.6.0
+aars~=0.3.3
 pandas
 fastapi

--- a/examples/fishnet_cod/requirements.txt
+++ b/examples/fishnet_cod/requirements.txt
@@ -1,6 +1,6 @@
 pydantic
 aiohttp
-aleph-sdk-python~=0.6.0
+aleph-sdk-python
 aars~=0.3.3
 pandas
 fastapi

--- a/examples/fishnet_cod/src/fishnet_cod/execution.py
+++ b/examples/fishnet_cod/src/fishnet_cod/execution.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from model import *
+from .model import *
 
 
 async def run_execution(execution: Execution) -> Optional[Execution]:

--- a/examples/fishnet_cod/src/fishnet_cod/execution.py
+++ b/examples/fishnet_cod/src/fishnet_cod/execution.py
@@ -5,16 +5,16 @@ from model import *
 async def run_execution(execution: Execution) -> Optional[Execution]:
     async def set_failed(execution, reason):
         execution.status = ExecutionStatus.FAILED
-        result = await Result.create(executionID=execution.id_hash, data=reason)
+        result = await Result(executionID=execution.id_hash, data=reason).save()
         execution.resultID = result.id_hash
-        return await execution.upsert()
+        return await execution.save()
 
     assert isinstance(execution, Execution)
     if execution.status != ExecutionStatus.PENDING:
         return execution
 
     execution.status = ExecutionStatus.RUNNING
-    await execution.upsert()
+    await execution.save()
 
     try:
         try:
@@ -72,12 +72,12 @@ async def run_execution(execution: Execution) -> Optional[Execution]:
         except Exception as e:
             return await set_failed(execution, f"Failed to run algorithm: {e}")
 
-        result_message = await Result.create(
+        result_message = await Result(
             executionID=execution.id_hash, data=str(result)
-        )
+        ).save()
         execution.status = ExecutionStatus.SUCCESS
         execution.resultID = result_message.id_hash
-        await execution.upsert()
+        await execution.save()
     except Exception as e:
         return await set_failed(execution, f"Unexpected error occurred: {e}")
     finally:

--- a/examples/fishnet_cod/src/fishnet_cod/model.py
+++ b/examples/fishnet_cod/src/fishnet_cod/model.py
@@ -77,6 +77,13 @@ class PermissionStatus(str, Enum):
     DENIED = "DENIED"
 
 
+class DatasetPermissionStatus(str, Enum):
+    NOT_REQUESTED = "NOT REQUESTED"
+    REQUESTED = "REQUESTED"
+    GRANTED = "GRANTED"
+    DENIED = "DENIED"
+
+
 class Permission(Record):
     timeseriesID: str
     algorithmID: Optional[str]

--- a/examples/fishnet_executor/requirements.txt
+++ b/examples/fishnet_executor/requirements.txt
@@ -1,3 +1,3 @@
-aleph-client
-aars
-fishnet-cod
+aleph-sdk-python~=0.6.0
+aars~=0.3.3
+fishnet-cod~=0.1.0

--- a/examples/fishnet_executor/requirements.txt
+++ b/examples/fishnet_executor/requirements.txt
@@ -1,3 +1,3 @@
-aleph-sdk-python~=0.6.0
+aleph-sdk-python
 aars~=0.3.3
 fishnet-cod~=0.1.0


### PR DESCRIPTION
- Fixed some syntax error in `fishnet-cod`
- Upgraded to use latest versions of `aars` and `aleph-sdk-python` instead of `aleph-client`
- Add further query parameters to `GET /datasets/`
  - `by`: Filter datasets by creator/owner
  - `view_as`: Generate `PermissionStatus`es for every `Dataset`, depending on the user address that views them
- WIP: Add pagination to most endpoints